### PR TITLE
ExposureCubeSun.h: Changed m_timeCut and m_gtis from vector reference to vectors.

### DIFF
--- a/SolarSystemTools/ExposureCubeSun.h
+++ b/SolarSystemTools/ExposureCubeSun.h
@@ -240,8 +240,8 @@ private:
 
    bool m_hasPhiDependence;
 
-   const std::vector< std::pair<double, double> > & m_timeCuts;
-   const std::vector< std::pair<double, double> > & m_gtis;
+   const std::vector< std::pair<double, double> > m_timeCuts;
+   const std::vector< std::pair<double, double> > m_gtis;
 
 	 /// Start of mission in Julian date
 		static const double s_mjd_missionStart;


### PR DESCRIPTION
I ran into this bug (https://github.com/fermi-lat/SolarSystemTools/issues/2) and I thought that this might fix it.

Cheers,
Emily